### PR TITLE
fix up SCTP_FUTURE_ASSOC error against Linux 5.0 kernel

### DIFF
--- a/src/dtls_sctp_chargen.c
+++ b/src/dtls_sctp_chargen.c
@@ -46,6 +46,11 @@
 #endif
 
 #include <netinet/sctp.h>
+#if !defined(SCTP_FUTURE_ASSOC) && defined(SCTP_EVENT)
+#define SCTP_FUTURE_ASSOC 0
+//      SCTP_CURRENT_ASSOC 1
+//      SCTP_ALL_ASSOC 2
+#endif
 #include <signal.h>
 
 #include <openssl/ssl.h>

--- a/src/dtls_sctp_discard.c
+++ b/src/dtls_sctp_discard.c
@@ -46,6 +46,11 @@
 #endif
 
 #include <netinet/sctp.h>
+#if !defined(SCTP_FUTURE_ASSOC) && defined(SCTP_EVENT)
+#define SCTP_FUTURE_ASSOC 0
+//      SCTP_CURRENT_ASSOC 1
+//      SCTP_ALL_ASSOC 2
+#endif
 #include <signal.h>
 
 #include <openssl/ssl.h>

--- a/src/dtls_sctp_echo.c
+++ b/src/dtls_sctp_echo.c
@@ -46,6 +46,11 @@
 #endif
 
 #include <netinet/sctp.h>
+#if !defined(SCTP_FUTURE_ASSOC) && defined(SCTP_EVENT)
+#define SCTP_FUTURE_ASSOC 0
+//      SCTP_CURRENT_ASSOC 1
+//      SCTP_ALL_ASSOC 2
+#endif
 
 #include <openssl/ssl.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
On Ubuntu 19.04 or other Linux 5.0 based Linux distro do have SCTP_EVENT feature without SCTP_FUTURE_ASSOC decleared:

```
$ make
cc -std=c99 -pedantic -Wall -g -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overlength-strings -I/usr/local/include -o dtls_sctp_chargen dtls_sctp_chargen.c -L/usr/local/lib -lssl -lcrypto -pthread -lm -ldl
dtls_sctp_chargen.c: In function ‘start_server’:
dtls_sctp_chargen.c:586:23: error: ‘SCTP_FUTURE_ASSOC’ undeclared (first use in this function); did you mean ‘SCTP_RESET_ASSOC’?
   event.se_assoc_id = SCTP_FUTURE_ASSOC;
                       ^~~~~~~~~~~~~~~~~
                       SCTP_RESET_ASSOC
dtls_sctp_chargen.c:586:23: note: each undeclared identifier is reported only once for each function it appears in
...
```

Fixes #10
